### PR TITLE
Make this a keystone auth plugin

### DIFF
--- a/rackspaceauth/v2.py
+++ b/rackspaceauth/v2.py
@@ -24,8 +24,9 @@ Rackspace identity plugins.
 # by end of year 2015.
 import requests
 requests.packages.urllib3.disable_warnings()
+from oslo_config import cfg
 
-from keystoneauth1.identity import v2
+from keystoneclient.auth.identity import v2
 
 AUTH_URL = "https://identity.api.rackspacecloud.com/v2.0/"
 
@@ -49,8 +50,24 @@ class APIKey(v2.Auth):
 
     def get_auth_data(self, headers=None):
         return {"RAX-KSKEY:apiKeyCredentials":
-                {"username": self.username, "apiKey": self.api_key}}
+               {"username": self.username, "apiKey": self.api_key}}
 
+    @classmethod
+    def get_options(cls):
+        options = super(APIKey, cls).get_options()
+        options.extend([
+            cfg.StrOpt('username',
+                       help='Username to authenticate with'),
+            cfg.StrOpt('api_key',
+                       help='APIKey to authenticate with'),
+            cfg.StrOpt('reauthenticate',
+                       help='Allow fetching a new token if current ' \
+                            'one is expired'),
+        ])
+        for option in options:
+            if not hasattr(option, 'deprecated'):
+                option.deprecated = []
+        return options
 
 class Password(v2.Auth):
 
@@ -73,6 +90,23 @@ class Password(v2.Auth):
         return {"passwordCredentials": {
                 "username": self.username, "password": self.password}}
 
+    @classmethod
+    def get_options(cls):
+        options = super(Password, cls).get_options()
+        options.extend([
+            cfg.StrOpt('username',
+                       help='Username to authenticate with'),
+            cfg.StrOpt('password',
+                       help='Password to authenticate with'),
+            cfg.StrOpt('reauthenticate',
+                       help='Allow fetching a new token if current ' \
+                            'one is expired'),
+        ])
+        for option in options:
+            if not hasattr(option, 'deprecated'):
+                option.deprecated = []
+        return options
+
 
 class Token(v2.Auth):
 
@@ -91,3 +125,17 @@ class Token(v2.Auth):
     def get_auth_data(self, headers=None):
         return {"token": {"id": self.token},
                 "tenantId": self.tenant_id}
+
+    @classmethod
+    def get_options(cls):
+        options = super(Token, cls).get_options()
+        options.extend([
+            cfg.StrOpt('tenant_id',
+                       help='Tenant ID to authenticate with'),
+            cfg.StrOpt('token',
+                       help='Token to authenticate with'),
+        ])
+        for option in options:
+            if not hasattr(option, 'deprecated'):
+                option.deprecated = []
+        return options

--- a/rackspaceauth/v2.py
+++ b/rackspaceauth/v2.py
@@ -31,7 +31,20 @@ from keystoneclient.auth.identity import v2
 AUTH_URL = "https://identity.api.rackspacecloud.com/v2.0/"
 
 
-class APIKey(v2.Auth):
+class RaxAuth(v2.Auth):
+
+    def get_endpoint(self, session, service_type=None, interface=None,
+                     region_name=None, service_name=None, version=None,
+                     **kwargs):
+        endpoint = super(RaxAuth, self).get_endpoint(
+            session, service_type, interface, region_name, service_name, version, **kwargs
+        )
+        if service_type == 'network':
+            endpoint = endpoint.strip('/v2.0')
+        return endpoint
+
+
+class APIKey(RaxAuth):
 
     def __init__(self, username=None, api_key=None, reauthenticate=True,
                  auth_url=AUTH_URL):
@@ -69,7 +82,7 @@ class APIKey(v2.Auth):
                 option.deprecated = []
         return options
 
-class Password(v2.Auth):
+class Password(RaxAuth):
 
     def __init__(self, username=None, password=None, reauthenticate=True,
                  auth_url=AUTH_URL):
@@ -108,7 +121,7 @@ class Password(v2.Auth):
         return options
 
 
-class Token(v2.Auth):
+class Token(RaxAuth):
 
     def __init__(self, tenant_id=None, token=None,
                  auth_url=AUTH_URL):

--- a/rackspaceauth/v2.py
+++ b/rackspaceauth/v2.py
@@ -37,7 +37,8 @@ class RaxAuth(v2.Auth):
                      region_name=None, service_name=None, version=None,
                      **kwargs):
         endpoint = super(RaxAuth, self).get_endpoint(
-            session, service_type, interface, region_name, service_name, version, **kwargs
+            session, service_type, interface, region_name, service_name,
+            version, **kwargs
         )
         if service_type == 'network':
             endpoint = endpoint.strip('/v2.0')
@@ -63,7 +64,7 @@ class APIKey(RaxAuth):
 
     def get_auth_data(self, headers=None):
         return {"RAX-KSKEY:apiKeyCredentials":
-               {"username": self.username, "apiKey": self.api_key}}
+                {"username": self.username, "apiKey": self.api_key}}
 
     @classmethod
     def get_options(cls):
@@ -74,13 +75,14 @@ class APIKey(RaxAuth):
             cfg.StrOpt('api_key',
                        help='APIKey to authenticate with'),
             cfg.StrOpt('reauthenticate',
-                       help='Allow fetching a new token if current ' \
+                       help='Allow fetching a new token if current '
                             'one is expired'),
         ])
         for option in options:
             if not hasattr(option, 'deprecated'):
                 option.deprecated = []
         return options
+
 
 class Password(RaxAuth):
 
@@ -112,7 +114,7 @@ class Password(RaxAuth):
             cfg.StrOpt('password',
                        help='Password to authenticate with'),
             cfg.StrOpt('reauthenticate',
-                       help='Allow fetching a new token if current ' \
+                       help='Allow fetching a new token if current '
                             'one is expired'),
         ])
         for option in options:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@
 pbr>=1.6
 keystoneauth1>=1.0.0
 requests!=2.8.0,>=2.5.2
+oslo.config>=3.2.0
+python-keystoneclient>=2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,5 +23,16 @@ classifier =
 packages =
     rackspaceauth
 
+[entry_points]
+keystoneclient.auth.plugin:
+    raxapikey = rackspaceauth.v2:APIKey
+    raxpass   = rackspaceauth.v2:Password
+    raxtoken  = rackspaceauth.v2:Token
+
+keystoneauth1.plugin:
+    raxapikey = rackspaceauth.v2:APIKey
+    raxpass   = rackspaceauth.v2:Password
+    raxtoken  = rackspaceauth.v2:Token
+
 [wheel]
 universal = 1


### PR DESCRIPTION
With this change, `auth_type` can be set in clouds.yaml for
openstackclient and shade, and you will be able to use your rackspace
apikey for those.