### PR TITLE
allow rackspaceauth to be a plugin for keystoneauth

### DIFF
--- a/rackspaceauth/loading/v2.py
+++ b/rackspaceauth/loading/v2.py
@@ -1,0 +1,69 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+from keystoneauth1 import loading
+from rackspaceauth import v2
+
+
+class APIKey(loading.BaseV2Loader):
+
+    @property
+    def plugin_class(self):
+        return v2.APIKey
+
+    def get_options(self):
+        options = super(APIKey, self).get_options()
+
+        options.extend([
+            loading.Opt('username',
+                        help='Username'),
+            loading.Opt('api-key',
+                        dest='api_key',
+                        help='API Key'),
+        ])
+        return options
+
+
+class Password(loading.BaseV2Loader):
+
+    @property
+    def plugin_class(self):
+        return v2.Password
+
+    def get_options(self):
+        options = super(Password, self).get_options()
+
+        options.extend([
+            loading.Opt('username',
+                        help='Username'),
+            loading.Opt('password',
+                        help='Password'),
+        ])
+        return options
+
+
+class Token(loading.BaseV2Loader):
+
+    @property
+    def plugin_class(self):
+        return v2.Token
+
+    def get_options(self):
+        options = super(Token, self).get_options()
+
+        options.extend([
+            loading.Opt('tenant-id',
+                        dest='tenant_id',
+                        help='Tenant ID'),
+            loading.Opt('token',
+                        help='Token'),
+        ])
+        return options

--- a/rackspaceauth/v2.py
+++ b/rackspaceauth/v2.py
@@ -30,7 +30,21 @@ from keystoneauth1.identity import v2
 AUTH_URL = "https://identity.api.rackspacecloud.com/v2.0/"
 
 
-class APIKey(v2.Auth):
+class RackspaceAuth(v2.Auth):
+
+    def get_endpoint(self, session, service_type=None, interface=None,
+                     region_name=None, service_name=None, version=None,
+                     **kwargs):
+        endpoint = super(RackspaceAuth, self).get_endpoint(
+            session, service_type, interface, region_name, service_name,
+            version, **kwargs
+        )
+        if service_type == 'network':
+            endpoint = endpoint.strip('/v2.0')
+        return endpoint
+
+
+class APIKey(RackspaceAuth):
 
     def __init__(self, username=None, api_key=None, reauthenticate=True,
                  auth_url=AUTH_URL):
@@ -52,7 +66,7 @@ class APIKey(v2.Auth):
                 {"username": self.username, "apiKey": self.api_key}}
 
 
-class Password(v2.Auth):
+class Password(RackspaceAuth):
 
     def __init__(self, username=None, password=None, reauthenticate=True,
                  auth_url=AUTH_URL):
@@ -74,7 +88,7 @@ class Password(v2.Auth):
                 "username": self.username, "password": self.password}}
 
 
-class Token(v2.Auth):
+class Token(RackspaceAuth):
 
     def __init__(self, tenant_id=None, token=None,
                  auth_url=AUTH_URL):

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,9 +25,9 @@ packages =
 
 [entry_points]
 keystoneauth1.plugin =
-    rackspaceapikey   = rackspaceauth.loading.v2:APIKey
-    rackspacepassword = rackspaceauth.loading.v2:Password
-    rackspacetoken    = rackspaceauth.loading.v2:Token
+    rackspace_apikey   = rackspaceauth.loading.v2:APIKey
+    rackspace_password = rackspaceauth.loading.v2:Password
+    rackspace_token    = rackspaceauth.loading.v2:Token
 
 [wheel]
 universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,5 +23,11 @@ classifier =
 packages =
     rackspaceauth
 
+[entry_points]
+keystoneauth1.plugin =
+    rackspaceapikey   = rackspaceauth.loading.v2:APIKey
+    rackspacepassword = rackspaceauth.loading.v2:Password
+    rackspacetoken    = rackspaceauth.loading.v2:Token
+
 [wheel]
 universal = 1


### PR DESCRIPTION
This will include rackspace* plugins as auth_types for keystone auth, which can be used in the clouds.yaml file for openstackclient and shade.