### PR TITLE
Support internal SSO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
+.stestr/
 .coverage
 .coverage.*
 .cache

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,5 @@
+Brian Curtin <brian@python.org>
+Daniel Wallace <danielwallace@gtmanfred.com>
+Jim Rollenhagen <jim@jimrollenhagen.com>
+briancurtin <brian.curtin@rackspace.com>
+briancurtin <brian@python.org>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,0 +1,39 @@
+CHANGES
+=======
+
+0.6.0
+-----
+
+* Add validate function
+
+0.5.0
+-----
+
+* urllib3 is now unvendored from requests
+* Update README.rst
+* Add a clouds.yaml example
+
+0.4.0
+-----
+
+* need to catch extra kwargs here
+
+0.3.0
+-----
+
+* seperate the auth\_type name with underscore
+* allow rackspaceauth to be a plugin for keystoneauth
+* Use the right argument name in APIKey example
+
+0.2.0
+-----
+
+* APIKey's key param needs to be api\_key
+
+0.1.0
+-----
+
+* Switch from markdown to restructuredtext
+* Add .travis.yml
+* Initial rackspaceauth checkin
+* Initial commit

--- a/rackspaceauth/tests/unit/test_rackspaceauth.py
+++ b/rackspaceauth/tests/unit/test_rackspaceauth.py
@@ -50,3 +50,17 @@ class TestRackspaceauth(unittest2.TestCase):
 
         self.assertEqual(data["tenantId"], tenant)
         self.assertEqual(data["token"]["id"], token)
+
+    def test_sso(self):
+        user = "plant"
+        password = "based"
+
+        auth = v2.SSO(username=user, password=password, internal=True)
+        data = auth.get_auth_data()
+
+        domain = data["RAX-AUTH:domain"]
+        self.assertEqual(domain["name"], "Rackspace")
+
+        creds = data["passwordCredentials"]
+        self.assertEqual(creds["username"], user)
+        self.assertEqual(creds["password"], password)

--- a/rackspaceauth/v2.py
+++ b/rackspaceauth/v2.py
@@ -29,6 +29,29 @@ from keystoneauth1.identity import v2
 
 AUTH_URL = "https://identity.api.rackspacecloud.com/v2.0/"
 
+# This identity-internal endpoint only works behind the Rackspace VPN.
+# It's use is intended for internal Rackspace users, as it supports
+# authentication via employee SSO.
+INTERNAL_AUTH_URL = "https://identity-internal.api.rackspacecloud.com/v2.0/"
+
+
+def validate(session, token, internal=False):
+    """Validate a token
+
+    :param session: An existing :class:`keystoneauth.session.Session`
+    :param str token: A token string
+    :param bool internal: Use Rackspace internal auth if True, otherwise
+                          use public auth. *Default: False*
+    """
+    headers = {"X-Auth-Token": token}
+    url = AUTH_URL if not internal else INTERNAL_AUTH_URL
+    response = session.get("%stokens/%s" % (url, token), headers=headers)
+    # If you're not allowed to validate, this will probably raise 403
+    # If you are and the token isn't valid, this will probably raise 404
+    response.raise_for_status()
+
+    return response.json()
+
 
 class RackspaceAuth(v2.Auth):
 
@@ -47,14 +70,18 @@ class RackspaceAuth(v2.Auth):
 class APIKey(RackspaceAuth):
 
     def __init__(self, username=None, api_key=None, reauthenticate=True,
-                 auth_url=AUTH_URL, **kwargs):
+                 auth_url=None, internal=False, **kwargs):
         """A plugin for authenticating with a username and API key
 
         :param str username: Username to authenticate with
         :param str key: API key to authenticate with
         :param bool reauthenticate: Allow fetching a new token if the current
                                     one is about to expire.
+        :param bool internal: Use Rackspace internal auth if True, otherwise
+                              use public auth. *Default: False*
         """
+        if auth_url is None:
+            auth_url = AUTH_URL if not internal else INTERNAL_AUTH_URL
         super(APIKey, self).__init__(auth_url, reauthenticate=reauthenticate)
 
         self.username = username
@@ -69,14 +96,18 @@ class APIKey(RackspaceAuth):
 class Password(RackspaceAuth):
 
     def __init__(self, username=None, password=None, reauthenticate=True,
-                 auth_url=AUTH_URL, **kwargs):
+                 auth_url=None, internal=False, **kwargs):
         """A plugin for authenticating with a username and password
 
         :param str username: Username to authenticate with
         :param str password: Password to authenticate with
         :param bool reauthenticate: Allow fetching a new token if the current
                                     one is about to expire.
+        :param bool internal: Use Rackspace internal auth if True, otherwise
+                              use public auth. *Default: False*
         """
+        if auth_url is None:
+            auth_url = AUTH_URL if not internal else INTERNAL_AUTH_URL
         super(Password, self).__init__(auth_url, reauthenticate=reauthenticate)
 
         self.username = username
@@ -91,12 +122,16 @@ class Password(RackspaceAuth):
 class Token(RackspaceAuth):
 
     def __init__(self, tenant_id=None, token=None,
-                 auth_url=AUTH_URL, **kwargs):
+                 auth_url=None, internal=False, **kwargs):
         """A plugin for authenticating with a username and password
 
         :param str tenant_id: Tenant ID to authenticate with
         :param str token: Token to authenticate with
+        :param bool internal: Use Rackspace internal auth if True, otherwise
+                              use public auth. *Default: False*
         """
+        if auth_url is None:
+            auth_url = AUTH_URL if not internal else INTERNAL_AUTH_URL
         super(Token, self).__init__(auth_url=auth_url, reauthenticate=False)
 
         self.tenant_id = tenant_id
@@ -105,3 +140,25 @@ class Token(RackspaceAuth):
     def get_auth_data(self, headers=None):
         return {"token": {"id": self.token},
                 "tenantId": self.tenant_id}
+
+
+class SSO(RackspaceAuth):
+
+    def __init__(self, username=None, password=None, internal=True, **kwargs):
+        """A plugin for authenticating with a username and password to SSO
+
+        :param str username: Username to authenticate with
+        :param str password: Password to authenticate with
+        :param bool internal: Use Rackspace internal auth if True, otherwise
+                              use public auth. *Default: True*
+        """
+        auth_url = AUTH_URL if not internal else INTERNAL_AUTH_URL
+        super(SSO, self).__init__(auth_url=auth_url, reauthenticate=False)
+
+        self.username = username
+        self.password = password
+
+    def get_auth_data(self, headers=None):
+        return {"RAX-AUTH:domain": {"name": "Rackspace"},
+                "passwordCredentials": {"username": self.username,
+                                        "password": self.password}}

--- a/rackspaceauth/v2.py
+++ b/rackspaceauth/v2.py
@@ -14,6 +14,8 @@
 Rackspace identity plugins.
 """
 
+from deprecation import deprecated
+
 # NOTE: The following two lines disable warning messages coming out of the
 # urllib3 that is vendored by requests. This is currently necessary to
 # silence a warning about an issue with the certificate in our identity
@@ -69,6 +71,8 @@ class RackspaceAuth(v2.Auth):
 
 class APIKey(RackspaceAuth):
 
+    @deprecated(deprecated_in="0.7.0", removed_in="1.0",
+                details="The `auth_url` is no longer used. Use `internal`.")
     def __init__(self, username=None, api_key=None, reauthenticate=True,
                  auth_url=None, internal=False, **kwargs):
         """A plugin for authenticating with a username and API key
@@ -95,6 +99,8 @@ class APIKey(RackspaceAuth):
 
 class Password(RackspaceAuth):
 
+    @deprecated(deprecated_in="0.7.0", removed_in="1.0",
+                details="The `auth_url` is no longer used. Use `internal`.")
     def __init__(self, username=None, password=None, reauthenticate=True,
                  auth_url=None, internal=False, **kwargs):
         """A plugin for authenticating with a username and password
@@ -121,6 +127,8 @@ class Password(RackspaceAuth):
 
 class Token(RackspaceAuth):
 
+    @deprecated(deprecated_in="0.7.0", removed_in="1.0",
+                details="The `auth_url` is no longer used. Use `internal`.")
     def __init__(self, tenant_id=None, token=None,
                  auth_url=None, internal=False, **kwargs):
         """A plugin for authenticating with a username and password

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@
 # process, which may cause wedges in the gate later.
 
 # Keep these the same as upstream SDK
+deprecation>=1.0 # Apache-2.0
 pbr>=1.6
-keystoneauth1>=1.0.0
+keystoneauth1>=3.3.0
 requests>=2.16.0
 urllib3

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,8 @@ name = rackspaceauth
 summary = keystoneauth plugin for Rackspace's authentication service
 description-file =
     README.rst
-author = Rackspace
-author-email = sdk-support@rackspace.com
+author = Brian Curtin
+author-email = brian.curtin@rackspace.com
 home-page = https://developer.rackspace.com/
 classifier =
     Environment :: OpenStack
@@ -28,6 +28,7 @@ keystoneauth1.plugin =
     rackspace_apikey   = rackspaceauth.loading.v2:APIKey
     rackspace_password = rackspaceauth.loading.v2:Password
     rackspace_token    = rackspaceauth.loading.v2:Token
+    rackspace_sso    = rackspaceauth.loading.v2:SSO
 
 [wheel]
 universal = 1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,5 +7,5 @@ hacking<0.11,>=0.10.0
 coverage>=3.6
 sphinx!=1.2.0,!=1.3b1,<1.3,>=1.1.2
 oslosphinx>=2.5.0 # Apache-2.0
-os-testr>=0.4.1
+stestr>=1.0.0 # Apache-2.0
 unittest2

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,8 @@ install_command = pip install -U {opts} {packages}
 setenv =
    VIRTUAL_ENV={envdir}
 deps = -r{toxinidir}/test-requirements.txt
-commands = python setup.py test --slowest --testr-args='{posargs}'
+commands = stestr --test-path=rackspaceauth/tests run {posargs}
+           stestr slowest
 
 [testenv:pep8]
 commands = flake8


### PR DESCRIPTION
This change implements support for Rackspace's internal SSO service. In doing so, this adds support to all of the auth plugins to optionally authenticate to that internal service, though the non-`SSO` plugin classes are likely to remain using the public service. As such, the `auth_url` parameter to each of the plugins has been deprecated while switching to plugins figuring out the URL by what's passed in `internal`.

This includes a few small touchups like bumping the requirements up and fixing up the tests so they actually run.